### PR TITLE
Fix PHP7 fatal error

### DIFF
--- a/wpe-securesubmit.php
+++ b/wpe-securesubmit.php
@@ -127,7 +127,6 @@ class wpe_securesubmit extends wpsc_merchant {
             $this->set_error_message(__('There was an error posting your payment.', 'wpsc'));
             $this->return_to_checkout();
             exit();
-            break;
         }
     }
 }


### PR DESCRIPTION
There was a break statement that was causing a fatal error in PHP versions 7.0 and up. The 'break' was unreachable anyways, as there was an `exit()` call immediately before it.

![screenshot from 2018-12-12 18-04-50](https://user-images.githubusercontent.com/8620392/49908717-17c24a00-fe39-11e8-872f-0e35160ce2d0.png)

Removing this line allows the plugin to work on hosts running PHP 7.0-7.2 without breaking compatibility with 5.6. I have not tested 7.3.