### PR TITLE
remove unreachable line

### DIFF
--- a/wpe-securesubmit.php
+++ b/wpe-securesubmit.php
@@ -127,7 +127,6 @@ class wpe_securesubmit extends wpsc_merchant {
             $this->set_error_message(__('There was an error posting your payment.', 'wpsc'));
             $this->return_to_checkout();
             exit();
-            break;
         }
     }
 }


### PR DESCRIPTION
was causing issues on certain versions of PHP due to being a `break` outside of the normal contexts